### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -1,5 +1,8 @@
 name: C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/dreamvrutik/VrootKV/security/code-scanning/4](https://github.com/dreamvrutik/VrootKV/security/code-scanning/4)

To fix this issue, add an explicit `permissions:` block to the workflow file.  
- The block should be set at the workflow root level (top of the file, beneath or just after `name:` and possibly after `on:`, but before `jobs:`), to apply to all jobs that do not set their own permissions.  
- For C++ CI workflows that only checkout code and upload artifacts, the minimal needed permission is usually `contents: read`.  
- If any job needs to upload artifacts (e.g., via actions/upload-artifact), this does **not** require write permissions on repository contents.  
- No jobs need to write to issues or pull requests, so only `contents: read` is required.
- Therefore, add the following block near the top:

```yaml
permissions:
  contents: read
```

This ensures `GITHUB_TOKEN` only has read access to repository contents for all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
